### PR TITLE
Update severity mapping between trivy and SonarQube

### DIFF
--- a/sonarqube.py
+++ b/sonarqube.py
@@ -6,11 +6,11 @@ import sys
 
 LOG_PREFIX = "[trivy][plugins][sonarqube]"
 TRIVY_SONARQUBE_SEVERITY = {
-    "UNKNOWN": "LOW",
+    "UNKNOWN": "INFO",
     "LOW": "LOW",
-    "MEDIUM": "LOW",
-    "HIGH": "MEDIUM",
-    "CRITICAL": "HIGH",
+    "MEDIUM": "MEDIUM",
+    "HIGH": "HIGH",
+    "CRITICAL": "BLOCKER",
 }
 
 

--- a/tests.py
+++ b/tests.py
@@ -116,7 +116,7 @@ class TestMakeSonarIssues(unittest.TestCase):
                     'cleanCodeAttribute': 'LOGICAL',
                     'impacts': [{
                          'softwareQuality': 'SECURITY',
-                         'severity': 'HIGH'
+                         'severity': 'BLOCKER'
                     }]
                 }
             ],
@@ -176,7 +176,7 @@ class TestMakeSonarIssues(unittest.TestCase):
                     'cleanCodeAttribute': 'LOGICAL',
                     'impacts': [{
                          'softwareQuality': 'SECURITY',
-                         'severity': 'HIGH'
+                         'severity': 'BLOCKER'
                     }]
                 }
             ],


### PR DESCRIPTION
Hi @umax ,
thank you for coming up with this idea and sharing it.

I agree with issue #7 and this PR is to implement the change itself.

Granted there is almost direct match between the severity keywords I consider this more intuitive.

Also I think there should be a difference between `LOW` and `UNKNOWN` rather than both being mapped to `LOW`, this allows us  to filter in SQ by `INFO` and evaluating whether or not it should be address more urgently or it is a low priority, w/o the noise of the `LOW`.

Thank you for reviewing and considering this change.

closes #7 